### PR TITLE
Fix nested multiline comments

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -188,7 +188,7 @@ hi link scalaTypeOperator Keyword
 hi link scalaTypeAnnotationParameter Function
 
 syn match scalaShebang "\%^#!.*" display
-syn region scalaMultilineComment start="/\*" end="\*/" contains=scalaMultilineComment,scalaDocLinks,scalaParameterAnnotation,scalaCommentAnnotation,scalaTodo,scalaCommentCodeBlock,@Spell keepend fold
+syn region scalaMultilineComment start="/\*" end="\*/" contains=scalaMultilineComment,scalaDocLinks,scalaParameterAnnotation,scalaCommentAnnotation,scalaTodo,scalaCommentCodeBlock,@Spell fold
 syn match scalaCommentAnnotation "@[_A-Za-z0-9$]\+" contained
 syn match scalaParameterAnnotation "\%(@tparam\|@param\|@see\)" nextgroup=scalaParamAnnotationValue skipwhite contained
 syn match scalaParamAnnotationValue /[.`_A-Za-z0-9$]\+/ contained

--- a/syntax/testfile.scala
+++ b/syntax/testfile.scala
@@ -180,4 +180,6 @@ class ScalaClass(i: Int = 12, b: Trait[A, Trait[B, C]]) extends B with SomeTrait
   val soManyEscapes = s"""\\\"\u0031\n\b\r\f\t""" // and a comment
   val soManyEscapes = f"""\\\"\u0031\n\b\r\f\t""" // and a comment
   val soManyEscapes = "\\\"\u0031\n\b\r\f\t" // and a comment
+
+  /* Comment /* with nested */ comment */
 }


### PR DESCRIPTION
Scala allows for nested multiline comments. This patch fixes the syntax
highlighting for this by removing `keepend` which prevents nesting.
